### PR TITLE
chore: migrate references to Act Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shrink IAM Actions
 
-[![NPM Version](https://img.shields.io/npm/v/@cloud-copilot/iam-shrink.svg?logo=nodedotjs)](https://www.npmjs.com/package/@cloud-copilot/iam-shrink) [![License: AGPL v3](https://img.shields.io/github/license/cloud-copilot/iam-shrink)](LICENSE.txt) [![GuardDog](https://github.com/cloud-copilot/iam-shrink/actions/workflows/guarddog.yml/badge.svg)](https://github.com/cloud-copilot/iam-shrink/actions/workflows/guarddog.yml) [![Known Vulnerabilities](https://snyk.io/test/github/cloud-copilot/iam-shrink/badge.svg?targetFile=package.json&style=flat-square)](https://snyk.io/test/github/cloud-copilot/iam-shrink?targetFile=package.json)
+[![NPM Version](https://img.shields.io/npm/v/@actsecurity/iam-shrink.svg?logo=nodedotjs)](https://www.npmjs.com/package/@actsecurity/iam-shrink) [![License: AGPL v3](https://img.shields.io/github/license/act-security-labs/iam-shrink)](LICENSE.txt) [![GuardDog](https://github.com/act-security-labs/iam-shrink/actions/workflows/guarddog.yml/badge.svg)](https://github.com/act-security-labs/iam-shrink/actions/workflows/guarddog.yml) [![Known Vulnerabilities](https://snyk.io/test/github/act-security-labs/iam-shrink/badge.svg?targetFile=package.json&style=flat-square)](https://snyk.io/test/github/act-security-labs/iam-shrink?targetFile=package.json)
 
 Built in the Unix philosophy, this is a small tool with two goals:
 
@@ -36,7 +36,7 @@ Existing wildcards will be removed under three conditions:
 
 ## Removing Preexisting Wildcards
 
-If you want to remove all existing wildcards from you policy you can use [iam-expand](https://github.com/cloud-copilot/iam-expand) before using iam-shrink.
+If you want to remove all existing wildcards from you policy you can use [iam-expand](https://github.com/act-security-labs/iam-expand) before using iam-shrink.
 
 ```bash
 curl "https://government-secrets.s3.amazonaws.com/secret-policy.json" | iam-expand | iam-shrink
@@ -53,7 +53,7 @@ curl "https://government-secrets.s3.amazonaws.com/secret-policy.json" | iam-expa
 You can install it globally. This also works in the default AWS CloudShell!
 
 ```bash
-npm install -g @cloud-copilot/iam-shrink
+npm install -g @actsecurity/iam-shrink
 ```
 
 _Depending on your configuration sudo may be required to install globally._
@@ -220,7 +220,7 @@ cat big-policy.json | iam-shrink --levels read list tagging
 You can use the shrink function in your own code.
 
 ```typescript
-import { shrink } from '@cloud-copilot/iam-shrink'
+import { shrink } from '@actsecurity/iam-shrink'
 
 const actions = [
   's3:GetBucketTagging',
@@ -238,7 +238,7 @@ console.log(shrunk)
 You can specify the number of iterations as well.
 
 ```typescript
-import { shrink } from '@cloud-copilot/iam-shrink'
+import { shrink } from '@actsecurity/iam-shrink'
 
 const bigListOfActions = getBigListOfActions()
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,7 +72,7 @@ async function run() {
         currentVersion() {
           return getPackageVersion()
         },
-        checkForUpdates: '@cloud-copilot/iam-shrink'
+        checkForUpdates: '@actsecurity/iam-shrink'
       }
     }
   )

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-const bugBaseUrl = 'https://github.com/cloud-copilot/iam-shrink/issues/new'
+const bugBaseUrl = 'https://github.com/act-security-labs/iam-shrink/issues/new'
 
 /**
  * The title of the bug report
@@ -47,7 +47,7 @@ export class ShrinkValidationError extends Error {
   ) {
     super(
       [
-        `@cloud-copilot/iam-shrink has failed validation and this is a bug.`,
+        `@actsecurity/iam-shrink has failed validation and this is a bug.`,
         `Please file a bug at ${bugUrl(desiredPatterns, errorMatch)}`
       ].join('\n')
     )

--- a/src/shrink.test.ts
+++ b/src/shrink.test.ts
@@ -639,7 +639,7 @@ describe('shrink.ts', () => {
 
       //Then we should get the reduced actions
       await expect(result).rejects.toThrow(
-        /@cloud-copilot\/iam-shrink has failed validation and this is a bug\./
+        /@actsecurity\/iam-shrink has failed validation and this is a bug\./
       )
     })
 


### PR DESCRIPTION
## Summary\n- update README package, badge, and repository references to @actsecurity and act-security-labs\n- update iam-expand link to act-security-labs\n- update CLI update-check and validation error package/GitHub references to @actsecurity/iam-shrink\n\n## Validation\n- npm run format\n- npm run build\n- npm test